### PR TITLE
fix: Implicit nullable resolveCallback

### DIFF
--- a/src/Items.php
+++ b/src/Items.php
@@ -29,7 +29,7 @@ class Items extends Field
     public $listFirst = false;
     public $detailItemComponent = 'detail-nova-items-field-item';
 
-    public function __construct($name, $attribute = null, callable $resolveCallback = null)
+    public function __construct($name, $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
 


### PR DESCRIPTION
Since PHP 8.4 nullable parameters should be type
hinted as such explicitly.

Questionmark syntax supported since PHP 7.1
Ref.: https://www.php.net/manual/en/migration71.new-features.php

Fixes #18