### PR TITLE
Fix implicit nullable deprecation in Items constructor for PHP 8.4+

### DIFF
--- a/src/Items.php
+++ b/src/Items.php
@@ -29,7 +29,7 @@ class Items extends Field
     public $listFirst = false;
     public $detailItemComponent = 'detail-nova-items-field-item';
 
-    public function __construct($name, $attribute = null, callable $resolveCallback = null)
+    public function __construct($name, $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
 


### PR DESCRIPTION
## Summary

- Fixes PHP 8.4+ deprecation in `Items::__construct()` where `$resolveCallback` was implicitly nullable (`callable $resolveCallback = null`)
- Marks the parameter as explicitly nullable (`?callable $resolveCallback = null`) — one-line change, no API or behavior change

## Problem

On PHP 8.4+, consumers see:
> `NovaItemsField\Items::__construct(): Implicitly marking parameter $resolveCallback as nullable is deprecated, the explicit nullable type must be used instead`
This affects Nova 4 users (e.g. tag `1.3.4`) running PHP 8.4/8.5.

## Note

The same fix was already merged on the `nova5` branch (PR #19). This PR targets the Nova 4 line only.

## Compatibility

`?callable` is supported since PHP 7.1; package requires `^7.3|^8.0`.

## Test plan

- [x] `php -l src/Items.php` — no syntax errors
- [x] Verified constructor signature uses explicit `?callable`
- [x] No automated tests in this repo; architecture tests pass in consuming apps on PHP 8.4+